### PR TITLE
Add some performance analytics

### DIFF
--- a/core/src/main/kotlin/com/alecstrong/sqlite/psi/core/psi/SqliteCompositeElement.kt
+++ b/core/src/main/kotlin/com/alecstrong/sqlite/psi/core/psi/SqliteCompositeElement.kt
@@ -45,6 +45,17 @@ internal interface SqliteCompositeElement : SqliteAnnotatedElement {
   fun tablesAvailable(child: PsiElement): List<LazyQuery>
 
   override fun getContainingFile(): SqliteFileBase
+
+  fun analytics(): Map<String, Analytics>
+}
+
+internal data class Analytics(
+  val timesCalled: Int = 0,
+  val timeTaken: Long = 0
+) {
+  operator fun plus(time: Long): Analytics {
+    return Analytics(timesCalled + 1, timeTaken + time)
+  }
 }
 
 class LazyQuery(val tableName: NamedElement, query: () -> QueryResult) {

--- a/core/src/main/kotlin/com/alecstrong/sqlite/psi/core/psi/SqliteCompositeElementImpl.kt
+++ b/core/src/main/kotlin/com/alecstrong/sqlite/psi/core/psi/SqliteCompositeElementImpl.kt
@@ -11,6 +11,8 @@ internal open class SqliteCompositeElementImpl(
     node: ASTNode
 ) : ASTWrapperPsiElement(node),
     SqliteCompositeElement {
+  private val analytics = mutableMapOf<String, Analytics>()
+
   override fun queryAvailable(child: PsiElement): List<QueryResult> {
     return (parent as SqliteCompositeElement).queryAvailable(this)
   }
@@ -26,9 +28,21 @@ internal open class SqliteCompositeElementImpl(
     return "${super.toString()}: ${(parent as SqliteCompositeElement).queryAvailable(this)}"
   }
 
+  inline fun <T> analyze(key: String, block: () -> T): T {
+    val start = System.currentTimeMillis()
+    try {
+      return block()
+    } finally {
+      val duration = System.currentTimeMillis() - start
+      analytics.put(key, analytics.getOrDefault(key, Analytics()) + duration)
+    }
+  }
+
   protected fun tableAvailable(child: PsiElement, name: String): List<QueryResult> {
     return tablesAvailable(child).filter { it.tableName.name == name }.map { it.query }
   }
+
+  override fun analytics() = analytics
 
   override fun getContainingFile() = super.getContainingFile() as SqliteFileBase
 }

--- a/core/src/main/kotlin/com/alecstrong/sqlite/psi/core/psi/mixins/ColumnAliasMixin.kt
+++ b/core/src/main/kotlin/com/alecstrong/sqlite/psi/core/psi/mixins/ColumnAliasMixin.kt
@@ -17,7 +17,7 @@ internal abstract class ColumnAliasMixin(
     SqliteColumnAlias {
   override val parseRule: (PsiBuilder, Int) -> Boolean = SqliteParser::column_alias_real
 
-  override fun source(): PsiElement {
+  override fun source(): PsiElement = analyze("source") {
     parent.let {
       return when (it) {
         is ResultColumnMixin -> it.expr!!

--- a/core/src/main/kotlin/com/alecstrong/sqlite/psi/core/psi/mixins/CompoundSelectStmtMixin.kt
+++ b/core/src/main/kotlin/com/alecstrong/sqlite/psi/core/psi/mixins/CompoundSelectStmtMixin.kt
@@ -17,14 +17,14 @@ abstract internal class CompoundSelectStmtMixin(
     node: ASTNode
 ) : SqliteCompositeElementImpl(node),
     SqliteCompoundSelectStmt {
-  override fun queryExposed(): List<QueryResult> {
+  override fun queryExposed(): List<QueryResult> = analyze("queryExposed") {
     if (detectRecursion() != null) {
       return emptyList()
     }
     return selectStmtList.first().queryExposed()
   }
 
-  override fun tablesAvailable(child: PsiElement): List<LazyQuery> {
+  override fun tablesAvailable(child: PsiElement): List<LazyQuery> = analyze("tablesAvailable") {
     return if (node.findChildByType(SqliteTypes.RECURSIVE) != null) {
       super.tablesAvailable(child) + commonTableExpressionList.map {
         LazyQuery(it.tableName) { it.queryExposed().single() }
@@ -36,7 +36,7 @@ abstract internal class CompoundSelectStmtMixin(
     }
   }
 
-  override fun queryAvailable(child: PsiElement): List<QueryResult> {
+  override fun queryAvailable(child: PsiElement): List<QueryResult> = analyze("queryAvailable") {
     if (child is SqliteExpr) {
       return queryExposed()
     } else if (child is SqliteOrderingTerm) {

--- a/core/src/main/kotlin/com/alecstrong/sqlite/psi/core/psi/mixins/CreateTableMixin.kt
+++ b/core/src/main/kotlin/com/alecstrong/sqlite/psi/core/psi/mixins/CreateTableMixin.kt
@@ -27,7 +27,7 @@ internal abstract class CreateTableMixin(
     } ?: queryAvailable(this).single()
   }
 
-  override fun queryAvailable(child: PsiElement): List<QueryResult> {
+  override fun queryAvailable(child: PsiElement): List<QueryResult> = analyze("queryAvailable") {
     val synthesizedColumns = if (node.findChildByType(SqliteTypes.WITHOUT) == null) {
       val columnNames = columnDefList.mapNotNull { it.columnName.name }
       listOf(SynthesizedColumn(

--- a/core/src/main/kotlin/com/alecstrong/sqlite/psi/core/psi/mixins/JoinClauseMixin.kt
+++ b/core/src/main/kotlin/com/alecstrong/sqlite/psi/core/psi/mixins/JoinClauseMixin.kt
@@ -13,7 +13,7 @@ abstract internal class JoinClauseMixin(
     node: ASTNode
 ) : SqliteCompositeElementImpl(node),
     SqliteJoinClause {
-  override fun queryAvailable(child: PsiElement): List<QueryResult> {
+  override fun queryAvailable(child: PsiElement): List<QueryResult> = analyze("queryAvailable") {
     if (child is SqliteJoinConstraint) {
       var queryAvailable = tableOrSubqueryList[0].queryExposed()
       tableOrSubqueryList.drop(1).zip(joinConstraintList)
@@ -38,7 +38,7 @@ abstract internal class JoinClauseMixin(
     return super.queryAvailable(child)
   }
 
-  override fun queryExposed(): List<QueryResult> {
+  override fun queryExposed(): List<QueryResult> = analyze("queryExposed") {
     var queryAvailable = tableOrSubqueryList[0].queryExposed()
     tableOrSubqueryList.drop(1)
         .zip(joinConstraintList)

--- a/core/src/main/kotlin/com/alecstrong/sqlite/psi/core/psi/mixins/SelectStmtMixin.kt
+++ b/core/src/main/kotlin/com/alecstrong/sqlite/psi/core/psi/mixins/SelectStmtMixin.kt
@@ -11,21 +11,21 @@ internal abstract class SelectStmtMixin(
     node: ASTNode
 ) : SqliteCompositeElementImpl(node),
     SqliteSelectStmt {
-  override fun queryAvailable(child: PsiElement): List<QueryResult> {
+  override fun queryAvailable(child: PsiElement): List<QueryResult> = analyze("queryAvailable") {
     if (child in resultColumnList) return fromQuery()
     if (child in exprList) return fromQuery() + super.queryAvailable(this)
     if (child == joinClause) return super.queryAvailable(child)
     return super.queryAvailable(child)
   }
 
-  override fun queryExposed(): List<QueryResult> {
+  override fun queryExposed(): List<QueryResult> = analyze("queryExposed") {
     if (valuesExpressionList.isNotEmpty()) {
       return listOf(QueryResult(null, valuesExpressionList.first().exprList))
     }
     return resultColumnList.flatMap { it.queryExposed() }
   }
 
-  internal fun fromQuery(): List<QueryResult> {
+  internal fun fromQuery(): List<QueryResult> = analyze("fromQuery") {
     joinClause?.let {
       return it.queryExposed()
     }

--- a/core/src/main/kotlin/com/alecstrong/sqlite/psi/core/psi/mixins/TableOrSubqueryMixin.kt
+++ b/core/src/main/kotlin/com/alecstrong/sqlite/psi/core/psi/mixins/TableOrSubqueryMixin.kt
@@ -9,25 +9,27 @@ internal abstract class TableOrSubqueryMixin(
     node: ASTNode
 ) : SqliteCompositeElementImpl(node),
     SqliteTableOrSubquery {
-  override fun queryExposed(): List<QueryResult> {
+  private val queryExposed: List<QueryResult> by lazy {
     tableName?.let { tableNameElement ->
       val result = tableAvailable(tableNameElement, tableNameElement.name)
       if (result.isEmpty()) {
-        return emptyList()
+        return@lazy emptyList<QueryResult>()
       }
       tableAlias?.let { alias ->
-        return listOf(QueryResult(alias, result.flatMap { it.columns }))
+        return@lazy listOf(QueryResult(alias, result.flatMap { it.columns }))
       }
-      return result
+      return@lazy result
     }
     compoundSelectStmt?.let {
       val result = it.queryExposed()
       tableAlias?.let { alias ->
-        return result.map { it.copy(table = alias) }
+        return@lazy result.map { it.copy(table = alias) }
       }
-      return result
+      return@lazy result
     }
-    joinClause?.let { return it.queryExposed() }
-    return tableOrSubqueryList.flatMap { it.queryExposed() }
+    joinClause?.let { return@lazy it.queryExposed() }
+    return@lazy tableOrSubqueryList.flatMap { it.queryExposed() }
   }
+
+  override fun queryExposed() = queryExposed
 }


### PR DESCRIPTION
Closes https://github.com/square/sqldelight/issues/239

Using this locally to help speed things up, hence the lazy's. For something like the from clause (`TableOrSubqueryMixin`) having it be lazy is hella helpful since every expression in the query checks that clause to see what columns are available for filters. That alone shaved like 75% of compiler time