### PR TITLE
Pin the column name for update setter expressions

### DIFF
--- a/core/src/main/grammars/sqlite.bnf
+++ b/core/src/main/grammars/sqlite.bnf
@@ -291,13 +291,16 @@ compound_operator ::= ( UNION ALL
                       | UNION
                       | INTERSECT
                       | EXCEPT )
-update_stmt ::= [ with_clause ] UPDATE [ OR ROLLBACK | OR ABORT | OR REPLACE | OR FAIL | OR IGNORE ] qualified_table_name SET column_name '=' setter_expression ( ',' column_name '=' setter_expression ) * [ WHERE expr ] {
+update_stmt ::= [ with_clause ] UPDATE [ OR ROLLBACK | OR ABORT | OR REPLACE | OR FAIL | OR IGNORE ] qualified_table_name SET column_name '=' setter_expression update_stmt_subsequent_setter * [ WHERE expr ] {
   mixin = "com.alecstrong.sqlite.psi.core.psi.mixins.MutatorMixin"
   pin = 4
 }
-update_stmt_limited ::= [ with_clause ] UPDATE [ OR ROLLBACK | OR ABORT | OR REPLACE | OR FAIL | OR IGNORE ] qualified_table_name SET column_name '=' setter_expression ( ',' column_name '=' setter_expression ) * [ WHERE expr ] [ [ ORDER BY ordering_term ( ',' ordering_term ) * ] LIMIT expr [ ( OFFSET | ',' ) expr ] ] {
+update_stmt_limited ::= [ with_clause ] UPDATE [ OR ROLLBACK | OR ABORT | OR REPLACE | OR FAIL | OR IGNORE ] qualified_table_name SET column_name '=' setter_expression update_stmt_subsequent_setter * [ WHERE expr ] [ [ ORDER BY ordering_term ( ',' ordering_term ) * ] LIMIT expr [ ( OFFSET | ',' ) expr ] ] {
   mixin = "com.alecstrong.sqlite.psi.core.psi.mixins.MutatorMixin"
   pin = 4
+}
+update_stmt_subsequent_setter ::= ',' column_name '=' setter_expression {
+  pin = 1
 }
 setter_expression ::= expr
 qualified_table_name ::= [ database_name '.' ] table_name [ INDEXED BY index_name | NOT INDEXED ]


### PR DESCRIPTION
Closes https://github.com/square/sqldelight/issues/813

The parser happens left to right, but since this rule is optional: `( ',' column_name = setter_expr) *` it cant figure out how to recover from errors. This change makes it so that if you type

```
UPDATE table
SET column = ?, c
```

the `,` character is pinned and so the parser knows to begin parsing a `update_stmt_subsequent_setter`, and since a column_name must follow a coma in that rule, `c` will parse as a `ColumnName`