### PR TITLE
Allow use of the table name as a column name in FTS tables

### DIFF
--- a/core/src/main/kotlin/com/alecstrong/sqlite/psi/core/psi/mixins/CreateVirtualTableMixin.kt
+++ b/core/src/main/kotlin/com/alecstrong/sqlite/psi/core/psi/mixins/CreateVirtualTableMixin.kt
@@ -20,7 +20,7 @@ internal abstract class CreateVirtualTableMixin(
       listOf(
           SynthesizedColumn(
               table = this,
-              acceptableValues = listOf("docid", "rowid", "oid", "_oid_")
+              acceptableValues = listOf("docid", "rowid", "oid", "_oid_", tableName.name)
           )
       )
     } else {

--- a/core/src/test/fixtures/fts-tables/Test.s
+++ b/core/src/test/fixtures/fts-tables/Test.s
@@ -15,3 +15,21 @@ WHERE content LIKE '%' | ? | '%';
 
 SELECT docid
 FROM data;
+
+SELECT *
+FROM data
+WHERE data MATCH ?;
+
+SELECT *
+FROM data
+WHERE data.data MATCH ?;
+
+SELECT *
+FROM data
+WHERE main.data.data MATCH ?
+ORDER BY rank(matchinfo(data));
+
+-- Expected failure - data is not a valid column in this context
+SELECT *
+FROM data
+WHERE main.data MATCH ?;

--- a/core/src/test/fixtures/fts-tables/failure.txt
+++ b/core/src/test/fixtures/fts-tables/failure.txt
@@ -1,0 +1,1 @@
+Test.s line 35:6 - No table found with name main


### PR DESCRIPTION
Currently, it's not possible to use the table name of an FTS table as a column name in SQLDelight (https://github.com/square/sqldelight/issues/1340), so a statement like the following would be considered invalid, though it shouldn't be.

`SELECT * FROM docs WHERE docs MATCH ? ORDER BY rank(matchinfo(docs));`

This change fixes that and adds tests to verify that the cases described in the SQLite FTS docs work as expected.

```
-- Example schema
CREATE VIRTUAL TABLE docs USING fts4(content);

-- Example queries
SELECT * FROM docs WHERE docs MATCH 'sqlite';              -- OK.
SELECT * FROM docs WHERE docs.docs MATCH 'sqlite';         -- OK.
SELECT * FROM docs WHERE main.docs.docs MATCH 'sqlite';    -- OK.
SELECT * FROM docs WHERE main.docs MATCH 'sqlite';         -- Error.
```
Source: https://www.sqlite.org/fts3.html
