### PR TITLE
Handle Windows line endings in tests

### DIFF
--- a/core/src/test/kotlin/com/alecstrong/sqlite/psi/core/FixturesTest.kt
+++ b/core/src/test/kotlin/com/alecstrong/sqlite/psi/core/FixturesTest.kt
@@ -60,4 +60,4 @@ class FixturesTest(val fixtureRoot: File, val name: String) {
   }
 }
 
-private fun String.splitLines() = split("\\r\\n?".toRegex())
+private fun String.splitLines() = split("\\r?\\n".toRegex())

--- a/core/src/test/kotlin/com/alecstrong/sqlite/psi/core/FixturesTest.kt
+++ b/core/src/test/kotlin/com/alecstrong/sqlite/psi/core/FixturesTest.kt
@@ -37,7 +37,7 @@ class FixturesTest(val fixtureRoot: File, val name: String) {
     val expectedFailure = File(fixtureRoot, "failure.txt")
     if (expectedFailure.exists()) {
       assertWithMessage(sourceFiles.toString()).that(errors).containsExactlyElementsIn(
-          expectedFailure.readText().split("\n").filterNot { it.isEmpty() }
+          expectedFailure.readText().splitLines().filter { it.isNotEmpty() }
       )
     } else {
       assertWithMessage(sourceFiles.toString()).that(errors).isEmpty()
@@ -59,3 +59,5 @@ class FixturesTest(val fixtureRoot: File, val name: String) {
         .map { arrayOf(it, it.name) }
   }
 }
+
+private fun String.splitLines() = split("\\r\\n?".toRegex())


### PR DESCRIPTION
For those of us using Windows, the default Git EOL setting will check out in CRLF and that causes a bunch of test failures locally.  While it can be fixed by changing the Git settings, it doesn't look like the line endings are important to the tests, so it seems like a good idea to handle either EOL scheme. Reduces the head scratching when you try to get the project to build the first time.

As an aside, this is an issue with SQLDelight too, though I'm also seeing some added path ordering differences.