### PR TITLE
Fix grammar "create view"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ out/
 lib/
 build/
 .DS_Store
+local.properties

--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,3 @@ out/
 lib/
 build/
 .DS_Store
-local.properties

--- a/core/src/main/grammars/sqlite.bnf
+++ b/core/src/main/grammars/sqlite.bnf
@@ -108,7 +108,7 @@ create_trigger_stmt ::= CREATE [ TEMP | TEMPORARY ] TRIGGER [ IF NOT EXISTS ] [ 
   mixin = "com.alecstrong.sqlite.psi.core.psi.mixins.CreateTriggerMixin"
   pin = 6
 }
-create_view_stmt ::= CREATE [ TEMP | TEMPORARY ] VIEW [ IF NOT EXISTS ] [ database_name '.' ] view_name AS compound_select_stmt {
+create_view_stmt ::= CREATE [ TEMP | TEMPORARY ] VIEW [ IF NOT EXISTS ] [ database_name '.' ] view_name[ '(' column_alias ( ',' column_alias ) * ')' ] AS compound_select_stmt {
   mixin = "com.alecstrong.sqlite.psi.core.psi.mixins.CreateViewMixin"
   implements = "com.alecstrong.sqlite.psi.core.psi.TableElement"
   pin = 6

--- a/core/src/test/fixtures/view-columns-validation-failures/Test.s
+++ b/core/src/test/fixtures/view-columns-validation-failures/Test.s
@@ -2,10 +2,7 @@ CREATE TABLE test (
   _id INTEGER NOT NULL PRIMARY KEY
 );
 
-CREATE VIEW view1 AS
-SELECT *
-FROM test;
-
-CREATE VIEW view2 AS
+CREATE VIEW view1(first_name,second_name)
+AS
 SELECT *
 FROM test;

--- a/core/src/test/fixtures/view-columns-validation-failures/failure.txt
+++ b/core/src/test/fixtures/view-columns-validation-failures/failure.txt
@@ -1,1 +1,1 @@
-Test.s line 5:0 - number of aliases is different from the number of colums
+Test.s line 5:0 - number of aliases is different from the number of columns

--- a/core/src/test/fixtures/view-columns-validation-failures/failure.txt
+++ b/core/src/test/fixtures/view-columns-validation-failures/failure.txt
@@ -1,0 +1,1 @@
+Test.s line 5:0 - number of aliases is different from the number of colums

--- a/core/src/test/fixtures/view-columns-validation/Test.s
+++ b/core/src/test/fixtures/view-columns-validation/Test.s
@@ -2,10 +2,7 @@ CREATE TABLE test (
   _id INTEGER NOT NULL PRIMARY KEY
 );
 
-CREATE VIEW view1 AS
-SELECT *
-FROM test;
-
-CREATE VIEW view2 AS
+CREATE VIEW view1(first_name)
+AS
 SELECT *
 FROM test;

--- a/local.properties
+++ b/local.properties
@@ -1,8 +1,0 @@
-## This file must *NOT* be checked into Version Control Systems,
-# as it contains information specific to your local configuration.
-#
-# Location of the SDK. This is only used by Gradle.
-# For customization when using a Version Control System, please read the
-# header note.
-#Wed Jul 31 13:13:23 CEST 2019
-sdk.dir=/home/cristianmg/Android/Sdk

--- a/local.properties
+++ b/local.properties
@@ -1,0 +1,8 @@
+## This file must *NOT* be checked into Version Control Systems,
+# as it contains information specific to your local configuration.
+#
+# Location of the SDK. This is only used by Gradle.
+# For customization when using a Version Control System, please read the
+# header note.
+#Wed Jul 31 13:13:23 CEST 2019
+sdk.dir=/home/cristianmg/Android/Sdk


### PR DESCRIPTION
The grammar was wrong, column-name list syntax was added in SQLite versions 3.9.0 (2015-10-14) and this was not added.
Added test with one argument and some arguments to check to function.

Links: https://sqlite.org/lang_createview.html,
https://github.com/square/sqldelight/issues/1426