### PR TITLE
Implement upsert clause

### DIFF
--- a/core/src/main/grammars/SqliteLexer.flex
+++ b/core/src/main/grammars/SqliteLexer.flex
@@ -184,6 +184,8 @@ STRING=('([^'])*'|\"([^\"])*\")
   "INTERSECT"            { return INTERSECT; }
   "EXCEPT"               { return EXCEPT; }
   "VACUUM"               { return VACUUM; }
+  "DO"                   { return DO; }
+  "NOTHING"              { return NOTHING; }
 
   {SPACE}                { return SPACE; }
   {COMMENT}              { return COMMENT; }

--- a/core/src/main/grammars/sqlite.bnf
+++ b/core/src/main/grammars/sqlite.bnf
@@ -233,7 +233,7 @@ literal_value ::= ( numeric_literal
   mixin = "com.alecstrong.sqlite.psi.core.psi.mixins.LiteralValueMixin"
 }
 numeric_literal ::= ( digit [ '.' ( digit ) * ] | '.' digit ) [ E [ '+' | '-' ] digit ]
-insert_stmt ::= [ with_clause ] ( INSERT OR REPLACE | REPLACE | INSERT OR ROLLBACK | INSERT OR ABORT | INSERT OR FAIL | INSERT OR IGNORE | INSERT ) INTO [ database_name '.' ] table_name [ '(' column_name ( ',' column_name ) * ')' ] ( VALUES values_expression ( ',' values_expression ) * | compound_select_stmt | DEFAULT VALUES ) [ upsert_clause ] {
+insert_stmt ::= [ with_clause ] ( INSERT OR REPLACE | REPLACE | INSERT OR ROLLBACK | INSERT OR ABORT | INSERT OR FAIL | INSERT OR IGNORE | INSERT ) INTO [ database_name '.' ] table_name [ AS table_alias ] [ '(' column_name ( ',' column_name ) * ')' ] ( VALUES values_expression ( ',' values_expression ) * | compound_select_stmt | DEFAULT VALUES ) [ upsert_clause ] {
   mixin = "com.alecstrong.sqlite.psi.core.psi.mixins.InsertStmtMixin"
   pin = 5
 }

--- a/core/src/main/grammars/sqlite.bnf
+++ b/core/src/main/grammars/sqlite.bnf
@@ -233,10 +233,15 @@ literal_value ::= ( numeric_literal
   mixin = "com.alecstrong.sqlite.psi.core.psi.mixins.LiteralValueMixin"
 }
 numeric_literal ::= ( digit [ '.' ( digit ) * ] | '.' digit ) [ E [ '+' | '-' ] digit ]
-insert_stmt ::= [ with_clause ] ( INSERT OR REPLACE | REPLACE | INSERT OR ROLLBACK | INSERT OR ABORT | INSERT OR FAIL | INSERT OR IGNORE | INSERT ) INTO [ database_name '.' ] table_name [ '(' column_name ( ',' column_name ) * ')' ] ( VALUES values_expression ( ',' values_expression ) * | compound_select_stmt | DEFAULT VALUES ) {
+insert_stmt ::= [ with_clause ] ( INSERT OR REPLACE | REPLACE | INSERT OR ROLLBACK | INSERT OR ABORT | INSERT OR FAIL | INSERT OR IGNORE | INSERT ) INTO [ database_name '.' ] table_name [ '(' column_name ( ',' column_name ) * ')' ] ( VALUES values_expression ( ',' values_expression ) * | compound_select_stmt | DEFAULT VALUES ) [ upsert_clause ] {
   mixin = "com.alecstrong.sqlite.psi.core.psi.mixins.InsertStmtMixin"
   pin = 5
 }
+upsert_clause ::= ON CONFLICT ( upsert_conflict_target DO UPDATE upsert_do_update | [ upsert_conflict_target ] DO NOTHING ) {
+    mixin = "com.alecstrong.sqlite.psi.core.psi.mixins.UpsertClauseMixin"
+}
+upsert_conflict_target ::= '(' indexed_column ( ',' indexed_column ) * ')' [ WHERE expr ]
+upsert_do_update ::= SET column_name '=' setter_expression update_stmt_subsequent_setter * [ WHERE expr ]
 pragma_stmt ::= PRAGMA [ database_name '.' ] pragma_name [ '=' pragma_value | '(' pragma_value ')' ] {
   pin = 1
 }

--- a/core/src/main/kotlin/com/alecstrong/sqlite/psi/core/psi/mixins/InsertStmtMixin.kt
+++ b/core/src/main/kotlin/com/alecstrong/sqlite/psi/core/psi/mixins/InsertStmtMixin.kt
@@ -70,8 +70,8 @@ internal abstract class InsertStmtMixin(
       }
 
       if (conflictResolution != null && upsertDoUpdate != null) {
-        annotationHolder.createErrorAnnotation(upsertDoUpdate, "Cannot use DO UPDATE when " +
-                "OR $conflictResolution conflict resolution algorithm was specified")
+        annotationHolder.createErrorAnnotation(upsertDoUpdate, "Cannot use DO UPDATE while " +
+                "also specifying a conflict resolution algorithm ($conflictResolution)")
       }
     }
 

--- a/core/src/main/kotlin/com/alecstrong/sqlite/psi/core/psi/mixins/UpsertClauseMixin.kt
+++ b/core/src/main/kotlin/com/alecstrong/sqlite/psi/core/psi/mixins/UpsertClauseMixin.kt
@@ -1,0 +1,33 @@
+package com.alecstrong.sqlite.psi.core.psi.mixins
+
+import com.alecstrong.sqlite.psi.core.psi.*
+import com.alecstrong.sqlite.psi.core.psi.SqliteCompositeElementImpl
+import com.intellij.lang.ASTNode
+import com.intellij.psi.PsiElement
+
+internal abstract class UpsertClauseMixin(
+        node: ASTNode
+) : SqliteCompositeElementImpl(node),
+        SqliteUpsertClause {
+
+    override fun tablesAvailable(child: PsiElement): Collection<LazyQuery> {
+        return super.tablesAvailable(child)
+    }
+    override fun queryAvailable(child: PsiElement): Collection<QueryElement.QueryResult> {
+        val insertStmt = (this.parent as InsertStmtMixin)
+        val tableName = insertStmt.tableName
+        val table = tablesAvailable(this).first { it.tableName.name == tableName.name }.query
+
+        if (child is SqliteUpsertConflictTarget) {
+            return super.queryAvailable(child)
+        }
+
+        if (child is SqliteUpsertDoUpdate) {
+            // TODO: Ensure the table alias is available here too (and add it to the grammar)
+            val excludedTable = QueryElement.QueryResult(SingleRow(tableName, "excluded"), table.columns, synthesizedColumns = table.synthesizedColumns)
+            return super.queryAvailable(child) + listOf(excludedTable)
+        }
+
+        return super.queryAvailable(child)
+    }
+}

--- a/core/src/main/kotlin/com/alecstrong/sqlite/psi/core/psi/mixins/UpsertClauseMixin.kt
+++ b/core/src/main/kotlin/com/alecstrong/sqlite/psi/core/psi/mixins/UpsertClauseMixin.kt
@@ -10,9 +10,6 @@ internal abstract class UpsertClauseMixin(
 ) : SqliteCompositeElementImpl(node),
         SqliteUpsertClause {
 
-    override fun tablesAvailable(child: PsiElement): Collection<LazyQuery> {
-        return super.tablesAvailable(child)
-    }
     override fun queryAvailable(child: PsiElement): Collection<QueryElement.QueryResult> {
         val insertStmt = (this.parent as InsertStmtMixin)
         val tableName = insertStmt.tableName
@@ -23,9 +20,13 @@ internal abstract class UpsertClauseMixin(
         }
 
         if (child is SqliteUpsertDoUpdate) {
-            // TODO: Ensure the table alias is available here too (and add it to the grammar)
-            val excludedTable = QueryElement.QueryResult(SingleRow(tableName, "excluded"), table.columns, synthesizedColumns = table.synthesizedColumns)
-            return super.queryAvailable(child) + listOf(excludedTable)
+            val excludedTable = QueryElement.QueryResult(
+                    SingleRow(tableName, "excluded"), table.columns,
+                    synthesizedColumns = table.synthesizedColumns)
+
+            val available = arrayListOf(excludedTable)
+            available += super.queryAvailable(child)
+            return available
         }
 
         return super.queryAvailable(child)

--- a/core/src/test/fixtures/upsert/Test.s
+++ b/core/src/test/fixtures/upsert/Test.s
@@ -1,0 +1,48 @@
+CREATE TABLE transaction(
+    transaction_id INTEGER PRIMARY KEY,
+    transaction_uuid TEXT NOT NULL UNIQUE,
+    opened_time TEXT NOT NULL,
+    finalized_time TEXT
+);
+
+INSERT INTO transaction(transaction_uuid, opened_time, finalized_time)
+VALUES (?, ?, ?)
+ON CONFLICT (transaction_uuid)
+DO UPDATE SET opened_time = excluded.opened_time, finalized_time = excluded.finalized_time;
+
+INSERT INTO transaction(transaction_uuid, opened_time, finalized_time)
+VALUES (?, ?, ?)
+ON CONFLICT (transaction_uuid)
+DO UPDATE SET finalized_time = excluded.finalized_time
+WHERE finalized_time IS NULL;
+
+INSERT INTO transaction(transaction_uuid, opened_time, finalized_time)
+VALUES (?, ?, ?)
+ON CONFLICT (transaction_uuid) DO NOTHING;
+
+INSERT INTO transaction(transaction_uuid, opened_time, finalized_time)
+VALUES (?, ?, ?)
+ON CONFLICT DO NOTHING;
+
+-- SET clause should be able to access CTE
+WITH t(foo) AS (VALUES (?))
+INSERT INTO transaction(transaction_uuid, opened_time, finalized_time)
+VALUES (?, ?, ?)
+ON CONFLICT (transaction_uuid)
+DO UPDATE SET opened_time = excluded.opened_time, finalized_time = (SELECT foo FROM t);
+
+-- Conflict list should only be able to access the transaction table, not the CTE
+WITH t(foo) AS (VALUES(?))
+INSERT INTO transaction(transaction_uuid, opened_time, finalized_time)
+VALUES (?, ?, ?)
+ON CONFLICT (foo) DO NOTHING;
+
+-- If specifying a conflict resolution strategy like REPLACE, the ON CONFLICT must be DO NOTHING
+INSERT OR REPLACE INTO transaction(transaction_uuid, opened_time, finalized_time)
+VALUES (?, ?, ?)
+ON CONFLICT (transaction_uuid) DO NOTHING;
+
+-- Cannot use DO UPDATE when OR REPLACE conflict resolution algorithm was specified
+INSERT OR REPLACE INTO transaction(transaction_uuid, opened_time, finalized_time)
+VALUES (?, ?, ?)
+ON CONFLICT (transaction_uuid) DO UPDATE SET opened_time = excluded.opened_time;

--- a/core/src/test/fixtures/upsert/Test.s
+++ b/core/src/test/fixtures/upsert/Test.s
@@ -2,7 +2,8 @@ CREATE TABLE transaction(
     transaction_id INTEGER PRIMARY KEY,
     transaction_uuid TEXT NOT NULL UNIQUE,
     opened_time TEXT NOT NULL,
-    finalized_time TEXT
+    finalized_time TEXT,
+    count INTEGER
 );
 
 INSERT INTO transaction(transaction_uuid, opened_time, finalized_time)
@@ -46,3 +47,23 @@ ON CONFLICT (transaction_uuid) DO NOTHING;
 INSERT OR REPLACE INTO transaction(transaction_uuid, opened_time, finalized_time)
 VALUES (?, ?, ?)
 ON CONFLICT (transaction_uuid) DO UPDATE SET opened_time = excluded.opened_time;
+
+-- Should pass
+INSERT INTO transaction(transaction_uuid, opened_time, finalized_time, count)
+VALUES (?, ?, ?, ?)
+ON CONFLICT (transaction_uuid) DO UPDATE SET count = transaction.count + excluded.count;
+
+-- Should fail
+INSERT INTO transaction(transaction_uuid, opened_time, finalized_time, count)
+VALUES (?, ?, ?, ?)
+ON CONFLICT (transaction_uuid) DO UPDATE SET count = transaction_alias.count + excluded.count;
+
+-- Should fail
+INSERT INTO transaction AS transaction_alias(transaction_uuid, opened_time, finalized_time, count)
+VALUES (?, ?, ?, ?)
+ON CONFLICT (transaction_uuid) DO UPDATE SET count = transaction.count + excluded.count;
+
+-- Should pass
+INSERT INTO transaction AS transaction_alias(transaction_uuid, opened_time, finalized_time, count)
+VALUES (?, ?, ?, ?)
+ON CONFLICT (transaction_uuid) DO UPDATE SET count = transaction_alias.count + excluded.count;

--- a/core/src/test/fixtures/upsert/failure.txt
+++ b/core/src/test/fixtures/upsert/failure.txt
@@ -1,2 +1,4 @@
-Test.s line 38:13 - No column found with name foo
-Test.s line 48:41 - Cannot use DO UPDATE when OR REPLACE conflict resolution algorithm was specified
+Test.s line 39:13 - No column found with name foo
+Test.s line 49:41 - Cannot use DO UPDATE when OR REPLACE conflict resolution algorithm was specified
+Test.s line 59:53 - No table found with name transaction_alias
+Test.s line 64:53 - No table found with name transaction

--- a/core/src/test/fixtures/upsert/failure.txt
+++ b/core/src/test/fixtures/upsert/failure.txt
@@ -1,4 +1,4 @@
 Test.s line 39:13 - No column found with name foo
-Test.s line 49:41 - Cannot use DO UPDATE when OR REPLACE conflict resolution algorithm was specified
+Test.s line 49:41 - Cannot use DO UPDATE while also specifying a conflict resolution algorithm (REPLACE)
 Test.s line 59:53 - No table found with name transaction_alias
 Test.s line 64:53 - No table found with name transaction

--- a/core/src/test/fixtures/upsert/failure.txt
+++ b/core/src/test/fixtures/upsert/failure.txt
@@ -1,0 +1,2 @@
+Test.s line 38:13 - No column found with name foo
+Test.s line 48:41 - Cannot use DO UPDATE when OR REPLACE conflict resolution algorithm was specified


### PR DESCRIPTION
Works towards https://github.com/cashapp/sqldelight/issues/1436

Still to do: table alias syntax of INSERT, maybe some other things?.. Do I need to implement `tablesAvailable` on `UpsertClauseMixin` too? It seems to work fine with me just implementing `queryAvailable` but I don't totally understand the difference between them

