### PR TITLE
Recognise INTEGER PRIMARY KEY without AUTOINCREMENT as having default value

### DIFF
--- a/core/src/main/kotlin/com/alecstrong/sqlite/psi/core/psi/mixins/InsertStmtMixin.kt
+++ b/core/src/main/kotlin/com/alecstrong/sqlite/psi/core/psi/mixins/InsertStmtMixin.kt
@@ -57,6 +57,14 @@ internal abstract class InsertStmtMixin(
           || it.node.findChildByType(SqliteTypes.AUTOINCREMENT) != null
     } || columnConstraintList.none {
       it.node.findChildByType(SqliteTypes.NOT) != null
-    }
+    } || (
+      // An INTEGER PRIMARY KEY is still considered to have a default value, even without specifying AUTOINCREMENT:
+      // https://www.sqlite.org/autoinc.html
+      // "On an INSERT, if the ROWID or INTEGER PRIMARY KEY column is not explicitly given a value, then it will be
+      // filled automatically with an unused integer .. regardless of whether or not the AUTOINCREMENT keyword is used."
+      this.typeName.text == "INTEGER" && this.columnConstraintList.any {
+        it.node.findChildByType(SqliteTypes.PRIMARY) != null
+      }
+    )
   }
 }

--- a/core/src/test/fixtures/insert-without-columns/Test.s
+++ b/core/src/test/fixtures/insert-without-columns/Test.s
@@ -1,4 +1,14 @@
 CREATE TABLE test (
+  -- Using TEXT for the primary key because an INTEGER PRIMARY KEY actually surprisingly
+  -- has a default value even without being AUTOINCREMENT.
+  _id TEXT NOT NULL PRIMARY KEY,
+  column1 TEXT DEFAULT 'sup',
+  column2 BLOB NOT NULL,
+  column3 REAL
+);
+
+CREATE TABLE test2 (
+  -- INTEGER NOT NULL PRIMARY KEY should be recognised as having a default value.
   _id INTEGER NOT NULL PRIMARY KEY,
   column1 TEXT DEFAULT 'sup',
   column2 BLOB NOT NULL,
@@ -22,3 +32,23 @@ INSERT INTO test(column1, column2, column3) VALUES (?, ?, ?);
 
 -- Fails since not all columns can have default values.
 INSERT INTO test DEFAULT VALUES;
+
+
+
+-- Works fine
+INSERT INTO test2 VALUES (?, ?, ?, ?);
+
+-- Also works fine. Nullable values receive default value of null.
+INSERT INTO test2 (_id, column1, column2) VALUES (?, ?, ?);
+
+-- Works fine, nullable and default value columns are okay.
+INSERT INTO test2 (_id, column2) VALUES (?, ?);
+
+-- Fails as column2 must be specified.
+INSERT INTO test2 (_id, column1, column3) VALUES (?, ?, ?);
+
+-- Works. An INTEGER PRIMARY KEY has a default value.
+INSERT INTO test2(column1, column2, column3) VALUES (?, ?, ?);
+
+-- Fails since not all columns can have default values.
+INSERT INTO test2 DEFAULT VALUES;

--- a/core/src/test/fixtures/insert-without-columns/failure.txt
+++ b/core/src/test/fixtures/insert-without-columns/failure.txt
@@ -1,3 +1,6 @@
-Test.s line 18:0 - Cannot populate default value for column column2, it must be specified in insert statement.
-Test.s line 21:0 - Cannot populate default value for column _id, it must be specified in insert statement.
-Test.s line 24:0 - Cannot populate default values for columns (_id, column2), they must be specified in insert statement.
+Test.s line 28:0 - Cannot populate default value for column column2, it must be specified in insert statement.
+Test.s line 31:0 - Cannot populate default value for column _id, it must be specified in insert statement.
+Test.s line 34:0 - Cannot populate default values for columns (_id, column2), they must be specified in insert statement.
+
+Test.s line 48:0 - Cannot populate default value for column column2, it must be specified in insert statement.
+Test.s line 54:0 - Cannot populate default value for column column2, it must be specified in insert statement.


### PR DESCRIPTION
Fixes https://github.com/cashapp/sqldelight/issues/1466

Is this solution good enough? I'm currently comparing the typename to the bare string literal "INTEGER", because as far as I can see actual column type info is only available once we're in the sqldelight layer, but the default value checking happens in sqlite-psi, so would need moving into an insert stmt mixin in sqldelight.