### PR TITLE
Parse TRUE and FALSE as numeric values

### DIFF
--- a/core/src/main/grammars/sqlite.bnf
+++ b/core/src/main/grammars/sqlite.bnf
@@ -232,7 +232,11 @@ literal_value ::= ( numeric_literal
                   | CURRENT_TIMESTAMP ) {
   mixin = "com.alecstrong.sqlite.psi.core.psi.mixins.LiteralValueMixin"
 }
-numeric_literal ::= ( digit [ '.' ( digit ) * ] | '.' digit ) [ E [ '+' | '-' ] digit ]
+numeric_literal ::= ( ( digit [ '.' ( digit ) * ] | '.' digit )
+                      | TRUE
+                      | FALSE
+                    ) [ E [ '+' | '-' ] digit ]
+
 insert_stmt ::= [ with_clause ] ( INSERT OR REPLACE | REPLACE | INSERT OR ROLLBACK | INSERT OR ABORT | INSERT OR FAIL | INSERT OR IGNORE | INSERT ) INTO [ database_name '.' ] table_name [ '(' column_name ( ',' column_name ) * ')' ] ( VALUES values_expression ( ',' values_expression ) * | compound_select_stmt | DEFAULT VALUES ) {
   mixin = "com.alecstrong.sqlite.psi.core.psi.mixins.InsertStmtMixin"
   pin = 5


### PR DESCRIPTION
SQLight interprets TRUE as 1 and FALSE as 0 and allow the usage
of them in all places where 1 and 0 would be valid.

Addresses: https://github.com/cashapp/sqldelight/issues/1507