### PR TITLE
Fix true & false literals by adding them to the lexer definition

### DIFF
--- a/core/src/main/grammars/SqliteLexer.flex
+++ b/core/src/main/grammars/SqliteLexer.flex
@@ -184,6 +184,8 @@ STRING=('([^'])*'|\"([^\"])*\")
   "INTERSECT"            { return INTERSECT; }
   "EXCEPT"               { return EXCEPT; }
   "VACUUM"               { return VACUUM; }
+  "TRUE"                 { return TRUE; }
+  "FALSE"                { return FALSE; }
 
   {SPACE}                { return SPACE; }
   {COMMENT}              { return COMMENT; }

--- a/core/src/test/fixtures/expression-failures/Test.s
+++ b/core/src/test/fixtures/expression-failures/Test.s
@@ -16,3 +16,5 @@ WHERE _id IN (
   SELECT _id, other_column
   FROM test
 );
+
+INSERT INTO test(other_column) VALUES (TRUE), (FALSE);


### PR DESCRIPTION
https://github.com/cashapp/sqldelight/issues/1507

I'm not sure what was happening before, did the parser implicitly declare the non-existent token types that #47 was using? Why isn't it a hard error to use put tokens in the grammar that don't exist? The generated parser capable of accepting TRUE and FALSE tokens, but the generated lexer didn't know about those tokens and so could never emit them.